### PR TITLE
fix: camera breaks app orientation configuration (#89)

### DIFF
--- a/Sources/Internal/UI/MCamera/MCamera+Config.swift
+++ b/Sources/Internal/UI/MCamera/MCamera+Config.swift
@@ -24,5 +24,6 @@ extension MCamera { @MainActor class Config {
 
     // MARK: Others
     var appDelegate: MApplicationDelegate.Type? = nil
+    var originalOrientationLock: UIInterfaceOrientationMask = .all
     var isCameraConfigured: Bool = false
 }}

--- a/Sources/Internal/UI/MCamera/MCamera.swift
+++ b/Sources/Internal/UI/MCamera/MCamera.swift
@@ -144,7 +144,7 @@ private extension MCamera {
 }
 private extension MCamera {
     func lockScreenOrientation(_ orientation: UIInterfaceOrientationMask?) {
-        config.appDelegate?.orientationLock = orientation ?? .all
+        config.appDelegate?.orientationLock = orientation ?? config.originalOrientationLock
         UINavigationController.attemptRotationToDeviceOrientation()
     }
     func notifyUserOfMediaCaptured(_ capturedMedia: MCameraMedia) {

--- a/Sources/Public/Camera Settings/Public+CameraSettings+MCamera.swift
+++ b/Sources/Public/Camera Settings/Public+CameraSettings+MCamera.swift
@@ -384,7 +384,13 @@ public extension MCamera {
      }
      ```
      */
-    func lockCameraInPortraitOrientation(_ appDelegate: MApplicationDelegate.Type) -> Self { config.appDelegate = appDelegate; manager.attributes.orientationLocked = true; return self }
+    func lockCameraInPortraitOrientation(_ appDelegate: MApplicationDelegate.Type) -> Self {
+      config.appDelegate = appDelegate
+      config.originalOrientationLock = appDelegate.orientationLock
+      manager.attributes.orientationLocked = true
+
+      return self
+    }
 
     /**
      Starts the camera session.


### PR DESCRIPTION
Issue: camera changes app orientation configuration e.g. your app allows only portrait orientation but after open camera and go back to your app then app can be rotated.

Bug in [this line](https://github.com/Mijick/Camera/blob/main/Sources/Internal/UI/MCamera/MCamera.swift#L147),  it reset app orientation when camera disappeared (`.all`) instead of using original orientation from app configuration.

`config.appDelegate?.orientationLock = orientation ?? .all`

Fixed by restoring to original app orientation instead of `.all` value.