### PR TITLE
Fix orientation lock setting app to `all` after closing camera

### DIFF
--- a/Sources/Internal/UI/MCamera/MCamera+Config.swift
+++ b/Sources/Internal/UI/MCamera/MCamera+Config.swift
@@ -24,5 +24,6 @@ extension MCamera { @MainActor class Config {
 
     // MARK: Others
     var appDelegate: MApplicationDelegate.Type? = nil
+    var originalOrientationLock: UIInterfaceOrientationMask = .all
     var isCameraConfigured: Bool = false
 }}

--- a/Sources/Internal/UI/MCamera/MCamera.swift
+++ b/Sources/Internal/UI/MCamera/MCamera.swift
@@ -144,7 +144,7 @@ private extension MCamera {
 }
 private extension MCamera {
     func lockScreenOrientation(_ orientation: UIInterfaceOrientationMask?) {
-        config.appDelegate?.orientationLock = orientation ?? .all
+        config.appDelegate?.orientationLock = orientation ?? config.originalOrientationLock
         UINavigationController.attemptRotationToDeviceOrientation()
     }
     func notifyUserOfMediaCaptured(_ capturedMedia: MCameraMedia) {

--- a/Sources/Public/Camera Settings/Public+CameraSettings+MCamera.swift
+++ b/Sources/Public/Camera Settings/Public+CameraSettings+MCamera.swift
@@ -384,7 +384,13 @@ public extension MCamera {
      }
      ```
      */
-    func lockCameraInPortraitOrientation(_ appDelegate: MApplicationDelegate.Type) -> Self { config.appDelegate = appDelegate; manager.attributes.orientationLocked = true; return self }
+    func lockCameraInPortraitOrientation(_ appDelegate: MApplicationDelegate.Type) -> Self {
+        config.appDelegate = appDelegate
+        config.originalOrientationLock = appDelegate.orientationLock
+        manager.attributes.orientationLocked = true
+
+        return self
+    }
 
     /**
      Starts the camera session.


### PR DESCRIPTION
Noted in [issue 89](https://github.com/Mijick/Camera/issues/89), after closing the `Camera`'s session we reset the `AppDelegate`'s orientation to `all`. This change will ensure we reset the orientation to the original state dictated by `AppDelegate`.