### PR TITLE
fix: add @Sendable annotations to CaptureDevice protocol completion h…

### DIFF
--- a/Sources/Internal/Manager/Helpers/Capture Device/CaptureDevice.swift
+++ b/Sources/Internal/Manager/Helpers/Capture Device/CaptureDevice.swift
@@ -47,8 +47,8 @@ protocol CaptureDevice: NSObject {
     func lockForConfiguration() throws
     func unlockForConfiguration()
     func isExposureModeSupported(_ exposureMode: AVCaptureDevice.ExposureMode) -> Bool
-    func setExposureModeCustom(duration: CMTime, iso: Float, completionHandler: ((CMTime) -> Void)?)
-    func setExposureTargetBias(_ bias: Float, completionHandler handler: ((CMTime) -> ())?)
+    func setExposureModeCustom(duration: CMTime, iso: Float, completionHandler: (@Sendable (CMTime) -> Void)?)
+    func setExposureTargetBias(_ bias: Float, completionHandler handler: (@Sendable (CMTime) -> ())?)
 }
 
 


### PR DESCRIPTION
- Mark completion handlers as @Sendable in setExposureModeCustom and setExposureTargetBias methods
- Resolves Xcode 26 compilation errors
- Fix maintains backward compatibility and compiles successfully on both Xcode 16.4.0 and Xcode 26.0.0-beta

Background:
In Xcode 16, AVCaptureDevice's Swift interface for these methods did not include @Sendable annotations 
on completion handlers. However, Xcode 26 now imports these Objective-C methods with @Sendable 
annotations, causing protocol conformance mismatches and compilation errors.

take `setExposureModeCustom` for example.
swift interface for AVCaptureDevice in Xcode 16.4.0
![image](https://github.com/user-attachments/assets/d9639bea-f4ed-4d44-aedd-60bdf86841dd)

and swift interface for AVCaptureDevice in Xcode 26.0.0-beta
![image](https://github.com/user-attachments/assets/07e58c17-109d-43fb-89fb-f034fcc86f4f)
